### PR TITLE
Update docmap parsing

### DIFF
--- a/src/activities/fetch-docmap.test.ts
+++ b/src/activities/fetch-docmap.test.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { mocked } from 'jest-mock';
+import { fetchDocMap } from './fetch-docmap';
+
+jest.mock('axios');
+
+describe('fetch-docmap-activity', () => {
+  it('does not find any docmaps in index', async () => {
+    // Arrange
+    const mockedGet = mocked(axios.get);
+
+    // @ts-ignore
+    mockedGet.mockImplementation(() => Promise.resolve({
+      data: {},
+      status: 200,
+    }));
+
+    const result = await fetchDocMap('http://somewhere.not.real/docmap/1234/213456');
+    expect(result).toStrictEqual('{}');
+  });
+});

--- a/src/activities/fetch-docmap.test.ts
+++ b/src/activities/fetch-docmap.test.ts
@@ -11,7 +11,7 @@ describe('fetch-docmap-activity', () => {
 
     // @ts-ignore
     mockedGet.mockImplementation(() => Promise.resolve({
-      data: {},
+      data: '{}',
       status: 200,
     }));
 

--- a/src/activities/fetch-docmap.ts
+++ b/src/activities/fetch-docmap.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export const fetchDocMap = async (docMapUrl: string): Promise<string> => {
+  const { data, status } = await axios.get<string>(docMapUrl, {
+    transformResponse: (res) => res,
+    responseType: 'text',
+  });
+
+  if (status !== 200) {
+    throw new Error('HTTP request for docmap failed (non-200 status)');
+  }
+  return JSON.stringify(data);
+};

--- a/src/activities/fetch-docmap.ts
+++ b/src/activities/fetch-docmap.ts
@@ -9,5 +9,12 @@ export const fetchDocMap = async (docMapUrl: string): Promise<string> => {
   if (status !== 200) {
     throw new Error('HTTP request for docmap failed (non-200 status)');
   }
-  return JSON.stringify(data);
+
+  // workaround bug in data-hub API https://github.com/elifesciences/data-hub-issues/issues/589
+  const json = JSON.parse(data);
+  if (Array.isArray(json)) {
+    return JSON.stringify(json[0]);
+  }
+
+  return data;
 };

--- a/src/activities/index.ts
+++ b/src/activities/index.ts
@@ -1,5 +1,6 @@
 export { extractMeca } from './extract-meca';
 export { convertXmlToJson } from './convert-xml-to-json';
 export { findAllDocmaps } from './find-all-docmaps';
+export { fetchDocMap } from './fetch-docmap';
 export { parseDocMap } from './parse-docmap';
 export { identifyBiorxivPreprintLocation, copyBiorxivPreprintToEPP } from './biorxiv';

--- a/src/activities/parse-docmap.ts
+++ b/src/activities/parse-docmap.ts
@@ -1,3 +1,3 @@
-import { DocMap, parsePreprintDocMap, ParseResult } from '../docmaps';
+import { parsePreprintDocMap, ParseResult } from '../docmaps';
 
-export const parseDocMap = async (docMapInput: string | DocMap): Promise<ParseResult> => parsePreprintDocMap(typeof docMapInput !== 'string' ? JSON.stringify(docMapInput) : docMapInput);
+export const parseDocMap = async (docMapInput: string): Promise<ParseResult> => parsePreprintDocMap(docMapInput);

--- a/src/workflows/import-content.ts
+++ b/src/workflows/import-content.ts
@@ -32,7 +32,7 @@ export async function importContent(version: Version): Promise<ImportContentOutp
 
   const preprintPath = await identifyBiorxivPreprintLocation(biorxivDoi);
 
-  const destinationPathForContent = `${config.eppContentUri}/${version.id}/v${version.versionIdentifier ? version.versionIdentifier : '0'}`;
+  const destinationPathForContent = `${config.eppContentUri}/${version.id}/v${version.versionIdentifier}`;
   await copyBiorxivPreprintToEPP(preprintPath, `${destinationPathForContent}/content.meca`);
 
   // Extract Meca

--- a/src/workflows/import-docmaps.ts
+++ b/src/workflows/import-docmaps.ts
@@ -30,8 +30,8 @@ export async function importDocmaps(docMapIndexUrl: string): Promise<DocMapImpor
 
   await Promise.all(docmaps.slice(0, 1).map(async (docmap) => {
     await startChild('importDocmap', {
-      args: [docmap],
-      workflowId: `import-docmap-${docmap.id}-${new Date().getTime()}`,
+      args: [docmap.id], // id contains the cononical URL of the docmap
+      workflowId: `import-docmap-${new Date().getTime()}`,
       parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
     });
   }));

--- a/src/workflows/import-docmaps.ts
+++ b/src/workflows/import-docmaps.ts
@@ -30,7 +30,7 @@ export async function importDocmaps(docMapIndexUrl: string): Promise<DocMapImpor
 
   await Promise.all(docmaps.slice(0, 1).map(async (docmap) => {
     await startChild('importDocmap', {
-      args: [docmap.id], // id contains the cononical URL of the docmap
+      args: [docmap.id], // id contains the canonical URL of the docmap
       workflowId: `import-docmap-${new Date().getTime()}`,
       parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
     });


### PR DESCRIPTION
Docmap are now not pulled from the index directly and passed as a parameter, but the ID (the URL) is passed instead
This allows for the data-hub API to not return full docmaps in future, reducing overhead and bandwidth.
This also reduces the size of parameters passed around the EPP import workflow, for performance, bandwidth and cost.