### PR TITLE
Remove `epp` namespace, sticking to default namespace

### DIFF
--- a/Dockerfile.temporalite
+++ b/Dockerfile.temporalite
@@ -3,4 +3,4 @@ ARG TARGETARCH
 
 ADD https://github.com/temporalio/temporalite/releases/download/v0.2.0/temporalite_0.2.0_linux_$TARGETARCH.tar.gz /
 RUN tar -xf temporalite_0.2.0_linux_$TARGETARCH.tar.gz
-CMD ["/temporalite", "start", "--namespace", "default", "--namespace", "epp", "--ip", "0.0.0.0"]
+CMD ["/temporalite", "start", "--namespace", "default", "--ip", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn install
 To run an import workflow, run:
 
 ```
-tctl --ns epp wf run import-docmaps-test -tq epp -wt importDocmaps --input '["http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/index"]'
+tctl wf run import-docmaps-test -tq epp -wt importDocmaps --input '["http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/index"]'
 ```
 
 This will kick of a full import for a docmap index from eLife's API.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23,7 +23,6 @@ async function run() {
     workflowsPath: require.resolve('./workflows'),
     taskQueue: 'epp',
     activities,
-    namespace: 'epp',
   });
 
   await worker.run();


### PR DESCRIPTION
Simplifies `tctl` calls while in dev