### PR TITLE
Change docmap endpoint used in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/publish_manuscript.md
+++ b/.github/ISSUE_TEMPLATE/publish_manuscript.md
@@ -14,7 +14,7 @@ assignees:
 
 Who can help: @QueenKraken, @nlisgo, @scottaubrey
 
-- [ ] Manuscript is in data hub index (https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=%%doi-prefix%%%2F%%doi-suffix%%)
+- [ ] Manuscript is in data hub index (https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-manuscript-id?manuscript_id=%%msid%%)
 
 or (only one should be ticked. remove other from description.)
 


### PR DESCRIPTION
Current `get-by-doi` endpoint does not work, and publisher specific `get-by-doi` endpoint will be removed at some point in the future, so we should use the eLife manuscript id one instead.