### PR TITLE
Replace temporalite with the new temporal dev-server

### DIFF
--- a/Dockerfile.temporal
+++ b/Dockerfile.temporal
@@ -1,0 +1,9 @@
+FROM debian:11.7-slim as build
+ARG TARGETARCH
+
+ADD https://temporal.download/cli/archive/latest?platform=linux&arch=$TARGETARCH /temporal.tar.gz
+RUN tar -xf temporal.tar.gz
+
+FROM debian:11.7-slim as run
+COPY --from=build /temporal /
+CMD ["/temporal", "server", "start-dev", "--namespace", "default", "--ip", "0.0.0.0"]

--- a/Dockerfile.temporalite
+++ b/Dockerfile.temporalite
@@ -1,6 +1,0 @@
-FROM debian:11.7-slim as base
-ARG TARGETARCH
-
-ADD https://github.com/temporalio/temporalite/releases/download/v0.2.0/temporalite_0.2.0_linux_$TARGETARCH.tar.gz /
-RUN tar -xf temporalite_0.2.0_linux_$TARGETARCH.tar.gz
-CMD ["/temporalite", "start", "--namespace", "default", "--ip", "0.0.0.0"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,10 +23,10 @@ services:
       exit 0;
       "
 
-  temporalite:
+  temporal:
     build:
       context: .
-      dockerfile: Dockerfile.temporalite
+      dockerfile: Dockerfile.temporal
     ports:
       - 7233:7233
       - 8233:8233
@@ -38,10 +38,10 @@ services:
       target: worker
     depends_on:
       - createbucket
-      - temporalite
+      - temporal
     environment:
       EPP_SERVER_URI: http://api:3000
-      TEMPORAL_SERVER: temporalite:7233
+      TEMPORAL_SERVER: temporal:7233
       AWS_ACCESS_KEY_ID: minio
       AWS_SECRET_ACCESS_KEY: miniotest
       S3_ENDPOINT: http://minio:9000


### PR DESCRIPTION
- based on upstream code rather than an experimental fork
- Newer version of temporal (including better UI)
- temporalite isn't being updated any more (due to the new sever)