### PR TITLE
Tidy up s3 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `docker compose` workflow above will restart the worker when your mounted fi
 To run an import workflow, run:
 
 ```shell
-tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://mock-datahub/enhanced-preprints/docmaps/v1/index"' 
+tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://mock-datahub/enhanced-preprints/docmaps/v1/index"'
 ```
 
 This will kick of a full import for a docmap index from eLife's API.
@@ -42,7 +42,7 @@ docker compose down --volumes
 To run a looped import workflow, run:
 
 ```shell
-tctl wf run -tq epp -wt pollDocMapIndex -wid docmap-index-poll -i '"http://mock-datahub/enhanced-preprints/docmaps/v1/index"' 
+tctl wf run -tq epp -wt pollDocMapIndex -wid docmap-index-poll -i '"http://mock-datahub/enhanced-preprints/docmaps/v1/index"'
 ```
 
 This will kick of a full import for a docmap index from eLife's API, then loop itself every hour (see next command to change this), skipping docmaps that have no changes.
@@ -50,7 +50,7 @@ This will kick of a full import for a docmap index from eLife's API, then loop i
 To change the sleep time, add a semantic time parameter to the `-i` inputs, for example `1 minute` or `5 minutes`:
 
 ```shell
-tctl wf run -tq epp -wt pollDocMapIndex -wid docmap-index-poll -i '"http://mock-datahub/enhanced-preprints/docmaps/v1/index"' -i '"1 minute"' 
+tctl wf run -tq epp -wt pollDocMapIndex -wid docmap-index-poll -i '"http://mock-datahub/enhanced-preprints/docmaps/v1/index"' -i '"1 minute"'
 ```
 
 ## Run without mocked services
@@ -64,7 +64,7 @@ docker compose -f docker-compose.yaml up
 Then you can use the following tctl command instead:
 
 ```shell
-tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/index"' 
+tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/index"'
 ```
 
 ## Run with a local instance of the API
@@ -81,4 +81,21 @@ To run with the local API but **without** the mocked services, omit `-f docker-c
 
 ```shell
 SERVER_DIR="../enhanced-preprints-server" APP_DIR="../enhanced-preprints-client" docker compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.localserver.yaml -f docker-compose.localapp.yaml up
+```
+
+## Run with "real" S3
+
+NOTE: this will alter the real resources in S3, and should only be used for testing
+
+Define a .env file with these variables:
+```bash
+AWS_ACCESS_KEY_ID=your access key
+AWS_SECRET_ACCESS_KEY=your secret key
+BUCKET_NAME=the S3 bucket to write to
+AWS_ROLE_ARN=a role to assume to have permission to source and destination # optional
+```
+
+then run docker-compose with the base, override and s3 configs, like below:
+```
+docker-compose  -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.s3.yaml  up
 ```

--- a/docker-compose.s3.yaml
+++ b/docker-compose.s3.yaml
@@ -1,0 +1,11 @@
+services:
+  worker:
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      S3_ENDPOINT: ${S3_ENDPOINT}
+      BUCKET_NAME: ${BUCKET_NAME}
+      AWS_ROLE_ARN: ${AWS_ROLE_ARN}
+volumes:
+  minio_storage: {}
+  mongodb_data: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,10 +42,10 @@ services:
     environment:
       EPP_SERVER_URI: http://api:3000
       TEMPORAL_SERVER: temporal:7233
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minio}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-miniotest}
-      AWS_ROLE_ARN: ${AWS_ROLE_ARN}
-      BUCKET_NAME: ${BUCKET_NAME}
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: miniotest
+      S3_ENDPOINT: http://minio:9000
+      BUCKET_NAME: epp
     restart: on-failure:5
     command:
       - yarn

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,9 +42,11 @@ services:
     environment:
       EPP_SERVER_URI: http://api:3000
       TEMPORAL_SERVER: temporal:7233
+
+      # EPP S3 bucket
+      S3_ENDPOINT: http://minio:9000
       AWS_ACCESS_KEY_ID: minio
       AWS_SECRET_ACCESS_KEY: miniotest
-      S3_ENDPOINT: http://minio:9000
       BUCKET_NAME: epp
     restart: on-failure:5
     command:

--- a/src/S3Bucket.ts
+++ b/src/S3Bucket.ts
@@ -43,7 +43,7 @@ export const getS3Client = (s3config: S3Config) => new S3Client({
   region: s3config.region,
 });
 
-export const getEPPS3Client = () => getS3Client(config.s3);
+export const getEPPS3Client = () => getS3Client(config.eppS3);
 
 export const parseS3Path = (s3Path: string): S3File => {
   const url = new URL(s3Path);

--- a/src/S3Bucket.ts
+++ b/src/S3Bucket.ts
@@ -21,11 +21,11 @@ const getAWSCredentials = (s3config: S3Config) => {
         RoleArn: s3config.awsAssumeRoleArn,
         DurationSeconds: 900,
       },
+      masterCredentials: {
+        accessKeyId: s3config.accessKey ?? '',
+        secretAccessKey: s3config.secretKey ?? '',
+      },
       clientConfig: {
-        credentials: {
-          accessKeyId: s3config.accessKey ?? '',
-          secretAccessKey: s3config.secretKey ?? '',
-        },
         region: s3config.region,
       },
     });

--- a/src/S3Bucket.ts
+++ b/src/S3Bucket.ts
@@ -43,7 +43,7 @@ export const getS3Client = (s3config: S3Config) => new S3Client({
   region: s3config.region,
 });
 
-export const getEPPS3Client = () => new S3Client(config.s3);
+export const getEPPS3Client = () => getS3Client(config.s3);
 
 export const parseS3Path = (s3Path: string): S3File => {
   const url = new URL(s3Path);

--- a/src/activities/convert-xml-to-json.ts
+++ b/src/activities/convert-xml-to-json.ts
@@ -11,7 +11,7 @@ import {
   PutObjectCommandOutput,
 } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
-import { constructEPPS3FilePath, getS3Client, S3File } from '../S3Bucket';
+import { constructEPPS3FilePath, getEPPS3Client, S3File } from '../S3Bucket';
 
 type ConvertXmlToJsonOutput = {
   result: PutObjectCommandOutput,
@@ -37,7 +37,7 @@ export const convertXmlToJson = async (version: VersionedReviewedPreprint): Prom
   const tmpDirectory = await mkdtemp(`${tmpdir()}/epp_json`);
   const localXmlFilePath = `${tmpDirectory}/article.xml`;
 
-  const s3 = getS3Client();
+  const s3 = getEPPS3Client();
   const source = constructEPPS3FilePath('article.xml', version);
   const object = await s3.send(new GetObjectCommand(source));
   await saveObjectToFile(object, localXmlFilePath);

--- a/src/activities/copy-source-meca.ts
+++ b/src/activities/copy-source-meca.ts
@@ -1,6 +1,6 @@
 import { CopyObjectCommand, CopyObjectCommandInput, CopyObjectCommandOutput } from '@aws-sdk/client-s3';
 import { VersionedReviewedPreprint } from '@elifesciences/docmap-ts';
-import { S3File, constructEPPS3FilePath, getS3Client } from '../S3Bucket';
+import { S3File, constructEPPS3FilePath, getEPPS3Client } from '../S3Bucket';
 
 type CopySourcePreprintToEPPOutput = {
   result: CopyObjectCommandOutput,
@@ -8,7 +8,7 @@ type CopySourcePreprintToEPPOutput = {
 };
 
 export const copySourcePreprintToEPP = async (version: VersionedReviewedPreprint): Promise<CopySourcePreprintToEPPOutput> => {
-  const S3Connection = getS3Client();
+  const S3Connection = getEPPS3Client();
 
   // extract bucket and Path for S3 client
   const bucketAndPath = version.preprint.content?.replace('s3://', '');

--- a/src/activities/extract-meca.ts
+++ b/src/activities/extract-meca.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'os';
 import path, { dirname } from 'path';
 import { GetObjectCommand, GetObjectCommandInput, PutObjectCommand } from '@aws-sdk/client-s3';
 import * as fs from 'fs';
-import { constructEPPS3FilePath, getS3Client } from '../S3Bucket';
+import { constructEPPS3FilePath, getEPPS3Client } from '../S3Bucket';
 import { NonRetryableError } from '../errors';
 
 export type MecaFile = {
@@ -66,7 +66,7 @@ const extractFileContents = async (zip: JSZip, item: MecaFile, toDir: string): P
 export const extractMeca = async (version: VersionedReviewedPreprint): Promise<MecaFiles> => {
   const tmpDirectory = await mkdtemp(`${tmpdir()}/epp_content`);
 
-  const s3 = getS3Client();
+  const s3 = getEPPS3Client();
   const source = constructEPPS3FilePath('content.meca', version);
 
   const getObjectCommandInput: GetObjectCommandInput = {

--- a/src/activities/generate-version-json.ts
+++ b/src/activities/generate-version-json.ts
@@ -1,6 +1,6 @@
 import { Article } from '@stencila/schema';
 import { GetObjectCommand, GetObjectCommandInput } from '@aws-sdk/client-s3';
-import { getS3Client } from '../S3Bucket';
+import { getEPPS3Client } from '../S3Bucket';
 import { EnhancedArticle } from './send-version-to-epp';
 import { ImportContentOutput } from '../workflows/import-content';
 
@@ -21,7 +21,7 @@ type GenerateVersionJson = (
 ) => Promise<EnhancedArticle>;
 
 export const generateVersionJson: GenerateVersionJson = async ({ importContentResult, msid, version }) => {
-  const s3 = getS3Client();
+  const s3 = getEPPS3Client();
 
   const getObjectCommandInput: GetObjectCommandInput = {
     Bucket: importContentResult.jsonContentFile.Bucket,

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export type S3Config = {
   accessKey?: string,
   secretKey?: string,
   region: string,
-  endPoint: string,
+  endPoint?: string,
   webIdentityTokenFile?: string,
   awsAssumeRoleArn?: string,
 };
@@ -27,7 +27,7 @@ export const config: Config = {
     accessKey: env.AWS_ACCESS_KEY_ID || undefined,
     secretKey: env.AWS_SECRET_ACCESS_KEY || undefined,
     region: env.S3_REGION || 'us-east-1',
-    endPoint: env.S3_ENDPOINT || 'https://s3.amazonaws.com',
+    endPoint: env.S3_ENDPOINT || undefined,
     webIdentityTokenFile: env.AWS_WEB_IDENTITY_TOKEN_FILE || undefined,
     awsAssumeRoleArn: env.AWS_ROLE_ARN || undefined,
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,5 +37,3 @@ export const config: Config = {
   prometheusBindAddress: env.PROMETHEUS_BIND_ADDRESS || '0.0.0.0:9464',
   temporalServer: env.TEMPORAL_SERVER || 'localhost',
 };
-
-console.log(config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,16 +24,18 @@ if (!env.EPP_SERVER_URI) {
 
 export const config: Config = {
   s3: {
-    accessKey: env.AWS_ACCESS_KEY_ID ?? undefined,
-    secretKey: env.AWS_SECRET_ACCESS_KEY ?? undefined,
-    region: env.S3_REGION ?? 'us-east-1',
-    endPoint: env.S3_ENDPOINT ?? 'https://s3.amazonaws.com',
-    webIdentityTokenFile: env.AWS_WEB_IDENTITY_TOKEN_FILE ?? undefined,
-    awsAssumeRoleArn: env.AWS_ROLE_ARN ?? undefined,
+    accessKey: env.AWS_ACCESS_KEY_ID || undefined,
+    secretKey: env.AWS_SECRET_ACCESS_KEY || undefined,
+    region: env.S3_REGION || 'us-east-1',
+    endPoint: env.S3_ENDPOINT || 'https://s3.amazonaws.com',
+    webIdentityTokenFile: env.AWS_WEB_IDENTITY_TOKEN_FILE || undefined,
+    awsAssumeRoleArn: env.AWS_ROLE_ARN || undefined,
   },
-  eppBucketName: env.BUCKET_NAME ?? 'epp',
+  eppBucketName: env.BUCKET_NAME || 'epp',
   eppServerUri: env.EPP_SERVER_URI,
-  biorxivURI: env.BIORXIV_URI ?? 'https://api.biorxiv.org',
-  prometheusBindAddress: env.PROMETHEUS_BIND_ADDRESS ?? '0.0.0.0:9464',
-  temporalServer: env.TEMPORAL_SERVER ?? 'localhost',
+  biorxivURI: env.BIORXIV_URI || 'https://api.biorxiv.org',
+  prometheusBindAddress: env.PROMETHEUS_BIND_ADDRESS || '0.0.0.0:9464',
+  temporalServer: env.TEMPORAL_SERVER || 'localhost',
 };
+
+console.log(config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export const config: Config = {
   s3: {
     accessKey: env.AWS_ACCESS_KEY_ID ?? undefined,
     secretKey: env.AWS_SECRET_ACCESS_KEY ?? undefined,
-    region: 'us-east-1',
+    region: env.S3_REGION ?? 'us-east-1',
     endPoint: env.S3_ENDPOINT ?? 'https://s3.amazonaws.com',
     webIdentityTokenFile: env.AWS_WEB_IDENTITY_TOKEN_FILE ?? undefined,
     awsAssumeRoleArn: env.AWS_ROLE_ARN ?? undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,16 +1,16 @@
 import { env } from 'process';
 
-type Config = {
-  s3: {
-    accessKey?: string,
-    secretKey?: string,
-    region: string,
-    endPoint: string,
-  },
-  awsAssumeRole: {
-    webIdentityTokenFile?: string,
-    roleArn?: string,
-  },
+export type S3Config = {
+  accessKey?: string,
+  secretKey?: string,
+  region: string,
+  endPoint: string,
+  webIdentityTokenFile?: string,
+  awsAssumeRoleArn?: string,
+};
+
+export type Config = {
+  s3: S3Config,
   eppBucketName: string,
   eppServerUri: string,
   biorxivURI: string,
@@ -28,10 +28,8 @@ export const config: Config = {
     secretKey: env.AWS_SECRET_ACCESS_KEY ?? undefined,
     region: 'us-east-1',
     endPoint: env.S3_ENDPOINT ?? 'https://s3.amazonaws.com',
-  },
-  awsAssumeRole: {
     webIdentityTokenFile: env.AWS_WEB_IDENTITY_TOKEN_FILE ?? undefined,
-    roleArn: env.AWS_ROLE_ARN ?? undefined,
+    awsAssumeRoleArn: env.AWS_ROLE_ARN ?? undefined,
   },
   eppBucketName: env.BUCKET_NAME ?? 'epp',
   eppServerUri: env.EPP_SERVER_URI,

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export type S3Config = {
 };
 
 export type Config = {
-  s3: S3Config,
+  eppS3: S3Config,
   eppBucketName: string,
   eppServerUri: string,
   biorxivURI: string,
@@ -23,7 +23,7 @@ if (!env.EPP_SERVER_URI) {
 }
 
 export const config: Config = {
-  s3: {
+  eppS3: {
     accessKey: env.AWS_ACCESS_KEY_ID || undefined,
     secretKey: env.AWS_SECRET_ACCESS_KEY || undefined,
     region: env.S3_REGION || 'us-east-1',


### PR DESCRIPTION
# Description

- Define S3 Connection config as a type
- Change getting an S3 client to need a config (as above)
- Change all access to S3 to be through a single function labelled `getEPPS3Client()`, which feeds the default config
- Set default docker to use minio locally
- add a new `docker-compose.s3.yaml` to use S3 entirely.

This is a stepping stone to https://github.com/elifesciences/enhanced-preprints-import/pull/527