### PR TITLE
Include client services in local dev env

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,25 @@
+server {
+  listen 80;
+
+  server_name localhost;
+
+  location / {
+    proxy_pass http://app:3000;
+  }
+
+  location /_next/webpack-hmr {
+    proxy_pass http://app:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+  }
+
+  location /api {
+    proxy_pass http://api:3000;
+  }
+
+  location /iiif {
+    proxy_pass http://image-server:8182;
+  }
+}

--- a/docker-compose.localapp.yaml
+++ b/docker-compose.localapp.yaml
@@ -1,25 +1,4 @@
 services:
-  ## Image Server
-  image-server:
-    image: ghcr.io/elifesciences/epp-image-server:master-32987c28-20230616.2129
-    environment:
-      SOURCE_STATIC: S3Source
-      S3SOURCE_ENDPOINT: http://minio:9000/
-      S3SOURCE_ACCESS_KEY_ID: minio
-      S3SOURCE_SECRET_KEY: miniotest
-      S3SOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX: /
-      S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME: epp
-    ports:
-      - "8182:8182"
-    volumes:
-      - ./data:/opt/epp/data
-    healthcheck:
-      test: curl http://image-server:8182/
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 2s
-
   yarn:
     build:
       context: ${APP_DIR}
@@ -34,39 +13,14 @@ services:
       context: ${APP_DIR}
       dockerfile: Dockerfile
       target: dev
-    healthcheck:
-      test: ["CMD-SHELL", "sh -c 'apk add curl; curl -X POST http://app:3000/'"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-    environment:
-      API_SERVER: http://api:3000
-      NEXT_PUBLIC_IMAGE_SERVER: /iiif
-      MANUSCRIPT_CONFIG_FILE: /opt/epp-client/data/manuscripts.json
-      IS_AUTOMATED: true
     depends_on:
-      api:
-        condition: service_healthy
       yarn:
         condition: service_completed_successfully
     ports:
       - 3001:3000
     volumes:
       - ${APP_DIR}/:/opt/epp-client/
-    
-  # Expose API and client via proxy
-  nginx:
-    image: nginx:latest
-    depends_on:
-      api:
-        condition: service_healthy
-      app:
-        condition: service_healthy
-    ports:
-      - 8080:80
-    volumes:
-      - ${APP_DIR}/.docker/nginx.conf:/etc/nginx/conf.d/default.conf
+      - node_modules:/opt/epp-client/node_modules
 
 volumes:
   node_modules:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -123,6 +123,57 @@ services:
     ports:
       - 3000:3000
 
+  app:
+    image: ghcr.io/elifesciences/enhanced-preprints-client:master-ae6f6d4a-20230624.0116
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'apk add curl; curl -X POST http://app:3000/'"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    environment:
+      API_SERVER: http://api:3000
+      NEXT_PUBLIC_IMAGE_SERVER: /iiif
+      MANUSCRIPT_CONFIG_FILE: /opt/epp-client/data/manuscripts.json
+      IS_AUTOMATED: true
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - 3001:3000
+
+  ## Image Server
+  image-server:
+    image: ghcr.io/elifesciences/epp-image-server:master-32987c28-20230616.2129
+    environment:
+      SOURCE_STATIC: S3Source
+      S3SOURCE_ENDPOINT: http://minio:9000/
+      S3SOURCE_ACCESS_KEY_ID: minio
+      S3SOURCE_SECRET_KEY: miniotest
+      S3SOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX: /automation/
+      S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME: epp
+    ports:
+      - "8182:8182"
+    healthcheck:
+      test: curl http://image-server:8182/
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 2s
+
+  ## Expose API, client and IIIF via proxy
+  nginx:
+    image: nginx:latest
+    depends_on:
+      api:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    ports:
+      - 8080:80
+    volumes:
+      - ./.docker/nginx.conf:/etc/nginx/conf.d/default.conf
+
 volumes:
   minio_storage: {}
   mongodb_data: {}


### PR DESCRIPTION
This change brings the defined client in local dev so that `docker-compose up` (or a combination that includes the default docker-compose.yaml files) will have a client wired up for automation to the local server and a proxy to proxy images and client running on port 8080 (similar to other projects).