### PR TITLE
Allow the S3 bucket path layout to reflect the directory layout in the meca file

### DIFF
--- a/src/S3Bucket.ts
+++ b/src/S3Bucket.ts
@@ -1,5 +1,6 @@
 import { VersionedReviewedPreprint } from '@elifesciences/docmap-ts';
 import { readFileSync } from 'fs';
+import { dirname, basename } from 'path';
 import { S3Client } from '@aws-sdk/client-s3';
 import { fromWebToken, fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { S3Config, config } from './config';
@@ -65,3 +66,5 @@ export const constructEPPS3FilePath = (filename: string, version: VersionedRevie
   Bucket: config.eppBucketName,
   Key: `${config.eppBucketPrefix}${version.id}/v${version.versionIdentifier}/${filename}`,
 });
+
+export const getPrefixlessKey = (file: S3File): string => file.Key.replace(new RegExp(`^${config.eppBucketPrefix}`), '');

--- a/src/activities/extract-meca.ts
+++ b/src/activities/extract-meca.ts
@@ -174,11 +174,11 @@ export const extractMeca = async (version: VersionedReviewedPreprint): Promise<M
     }));
   };
 
-  const articleUploadPromise = uploadItem(article, 'article.xml');
-  const figureUploadPromises = figures.map((figure) => uploadItem(figure, figure.fileName));
-  const tableUploadPromises = tables.map((table) => uploadItem(table, table.fileName));
-  const equationUploadPromises = tables.map((equation) => uploadItem(equation, equation.fileName));
-  const supplementUploadPromises = tables.map((supplement) => uploadItem(supplement, supplement.fileName));
+  const articleUploadPromise = uploadItem(article, article.path);
+  const figureUploadPromises = figures.map((figure) => uploadItem(figure, figure.path));
+  const tableUploadPromises = tables.map((table) => uploadItem(table, table.path));
+  const equationUploadPromises = tables.map((equation) => uploadItem(equation, equation.path));
+  const supplementUploadPromises = tables.map((supplement) => uploadItem(supplement, supplement.path));
 
   Context.current().heartbeat('Uploading all resources');
   await Promise.all([

--- a/src/workflows/import-content.ts
+++ b/src/workflows/import-content.ts
@@ -59,7 +59,7 @@ export async function importContent(version: VersionedReviewedPreprint): Promise
   // Extract Meca
   const mecaFiles = await extractMeca(version);
 
-  const { path: jsonContentFile } = await convertXmlToJson(version);
+  const { path: jsonContentFile } = await convertXmlToJson(version, mecaFiles);
 
   // fetch review content (if present)
   const reviewData = await fetchReviewContent(version);


### PR DESCRIPTION
This then allows us to consistently replace paths in the content with their new location in S3.

This is a fixes one issue causing https://github.com/elifesciences/enhanced-preprints-issues/issues/708