### PR TITLE
mark dummy-1 docmap 000001.1 is as published

### DIFF
--- a/mock-data/docmaps/dummy-1.json
+++ b/mock-data/docmaps/dummy-1.json
@@ -80,7 +80,22 @@
             }
           ]
         }
-      ]
+      ],
+      "next-step": "_:b1"
+    },
+    "_:b1": {
+      "inputs": [],
+      "actions": [],
+      "assertions": [{
+        "item": {
+          "type": "preprint",
+          "doi": "10.7554/000001.1",
+          "versionIdentifier": "1"
+        },
+        "status": "manuscript-published",
+        "happened": "2023-05-07T09:03:08+00:00"
+      }],
+      "previous-step": "_:b0"
     }
   }
 }


### PR DESCRIPTION
So that the client treats this as a published RPP.