### PR TITLE
feat: Update API version and add S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker compose -f docker-compose.yaml up
 Then you can use the following tctl command instead:
 
 ```shell
-tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/index"' -i '[]'
+tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/index"' -i '[]'
 ```
 
 ## Run with a local instance of the API
@@ -104,7 +104,7 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-
 Finally, you can run the `tctl` command to extract a slice of the Docmap index (so you don't index **all** Docmaps in your local environment), where the third argument is the start index and the last argument is the end index:
 
 ```shell
-tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/index"' -i '[]' -i 5 -i 30
+tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/index"' -i '[]' -i 5 -i 30
 ```
 
 ## Run with "real" S3 as a destination

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker compose -f docker-compose.yaml up
 Then you can use the following tctl command instead:
 
 ```shell
-tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/index"' -i '[]'
+tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/index"' -i '[]'
 ```
 
 ## Run with a local instance of the API
@@ -104,5 +104,29 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-
 Finally, you can run the `tctl` command to extract a slice of the Docmap index (so you don't index **all** Docmaps in your local environment), where the third argument is the start index and the last argument is the end index:
 
 ```shell
-tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/index"' -i '[]' -i 5 -i 30
+tctl wf run -tq epp -wt importDocmaps -wid docmap-index-import -i '"http://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/index"' -i '[]' -i 5 -i 30
+```
+
+## Run with "real" S3 as a destination
+
+NOTE: this will only write extract resources to the real S3, so you can verify that the process works
+
+Define a .env file with these variables:
+
+```bash
+AWS_ACCESS_KEY_ID=your access key
+AWS_SECRET_ACCESS_KEY=your secret key
+BUCKET_NAME=you will want to create an S3 bucket for your dev experiments
+```
+
+Then run docker-compose with the base, override and s3 configs, like below:
+
+```shell
+docker-compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.s3-epp.yaml up
+```
+
+You can combine the s3 source and destination to allow for retrieval from s3 source and preparing the assets and uploading them to S3:
+
+```shell
+docker-compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.s3.yaml -f docker-compose.s3-epp.yaml up
 ```

--- a/docker-compose.s3-epp.yaml
+++ b/docker-compose.s3-epp.yaml
@@ -1,0 +1,10 @@
+services:
+  worker:
+    environment:
+      AWS_ACCESS_KEY_ID: ${MECA_AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${MECA_AWS_SECRET_ACCESS_KEY}
+      S3_ENDPOINT:
+      BUCKET_NAME: ${BUCKET_NAME}
+volumes:
+  minio_storage: {}
+  mongodb_data: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -171,7 +171,7 @@ services:
   app:
     image: ghcr.io/elifesciences/enhanced-preprints-client:master-c0144b59-20230913.1334
     healthcheck:
-      test: sh -c 'apk add curl; curl -X POST http://client:3000/'
+      test: sh -c 'apk add curl; curl http://app:3000/'
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,12 @@ services:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: miniotest
     command: server --console-address ":9001" /data
+    healthcheck:
+      test: curl http://minio:9000/minio/health/live
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 2s
 
   createbucket:
     image: minio/mc:RELEASE.2022-12-24T15-21-38Z
@@ -41,6 +47,12 @@ services:
     ports:
       - 7233:7233
       - 8233:8233
+    healthcheck:
+      test: /temporal operator namespace list
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 2s
     volumes:
       - temporal_data:/data
 
@@ -63,6 +75,12 @@ services:
         condition: service_completed_successfully
       yarn:
         condition: service_completed_successfully
+      temporal:
+        condition: service_healthy
+      xslt:
+        condition: service_healthy
+      api:
+        condition: service_healthy
     environment:
       EPP_SERVER_URI: http://api:3000
       TEMPORAL_SERVER: temporal:7233
@@ -82,6 +100,12 @@ services:
     command:
       - yarn
       - start:worker:dev
+    healthcheck:
+      test: curl -s http://worker:9464/metrics  | grep 'temporal_worker_start{namespace="default",service_name="temporal-core-sdk",task_queue="epp"}'  | grep 1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 2s
     volumes:
       - ./src:/app/src
       - node_modules:/app/node_modules
@@ -128,7 +152,7 @@ services:
   api:
     image: ghcr.io/elifesciences/enhanced-preprints:master-416bf3bb-20230912.1944
     healthcheck:
-      test: ["CMD-SHELL", "sh -c 'apk add curl; curl http://api:3000/'"]
+      test: sh -c 'apk add curl; curl http://api:3000/'
       interval: 5s
       timeout: 5s
       retries: 10
@@ -147,7 +171,7 @@ services:
   app:
     image: ghcr.io/elifesciences/enhanced-preprints-client:master-c0144b59-20230913.1334
     healthcheck:
-      test: ["CMD-SHELL", "sh -c 'apk add curl; curl -X POST http://app:3000/'"]
+      test: sh -c 'apk add curl; curl -X POST http://client:3000/'
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
- Update the API endpoint version from v1 to v2 in README.md instructions
- Add instructions for running the application with a real S3 as a destination
- Add a new docker-compose.s3-epp.yaml file to define the environment for S3 support and volumes for minio storage and MongoDB data.