### PR TITLE
fix polling workflow not combining hashes when continuing as new

### DIFF
--- a/src/workflows/poll-docmap-index.ts
+++ b/src/workflows/poll-docmap-index.ts
@@ -16,5 +16,5 @@ export async function pollDocMapIndex(docMapIndexUrl: string, sleepTime: string 
   const { hashes: newHashes } = await importWf.result();
 
   await sleep(sleepTime);
-  await continueAsNew<typeof pollDocMapIndex>(docMapIndexUrl, sleepTime, newHashes);
+  await continueAsNew<typeof pollDocMapIndex>(docMapIndexUrl, sleepTime, hashes.concat(newHashes));
 }


### PR DESCRIPTION
This relates to the bug found in testing https://github.com/elifesciences/enhanced-preprints-issues/issues/905