### PR TITLE
resolve child importDocmap workflows after sync'ing statefile

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,13 @@
-export type ImportMessage = {
+export type ImportDocmapsMessage = {
   status: 'SUCCESS' | 'SKIPPED'
   message: string;
+  results: ImportDocmapMessage[],
+};
+
+export type ImportDocmapMessage = {
+  results: {
+    id: string,
+    versionIdentifier: string,
+    result: string,
+  }[]
 };

--- a/src/workflows/import-docmap.ts
+++ b/src/workflows/import-docmap.ts
@@ -7,6 +7,7 @@ import {
 import type * as activities from '../activities/index';
 import { importContent } from './import-content';
 import { useWorkflowState } from '../hooks/useWorkflowState';
+import { ImportDocmapMessage } from '../types';
 
 const { parseDocMap } = proxyActivities<typeof activities>({
   startToCloseTimeout: '1 minute',
@@ -31,13 +32,7 @@ const {
 
 export const store = useWorkflowState(workflowInfo().workflowId, true);
 
-type ImportDocmapOutput = {
-  id: string,
-  versionIdentifier: string,
-  result: string,
-};
-
-export async function importDocmap(url: string): Promise<ImportDocmapOutput[]> {
+export async function importDocmap(url: string): Promise<ImportDocmapMessage> {
   upsertSearchAttributes({
     DocmapURL: [url],
   });
@@ -47,7 +42,7 @@ export async function importDocmap(url: string): Promise<ImportDocmapOutput[]> {
     ManuscriptId: [result.id],
   });
 
-  return Promise.all(
+  const results = await Promise.all(
     result.versions.map(async (version) => {
       const importContentResult = await executeChild(importContent, {
         args: [version],
@@ -75,4 +70,8 @@ export async function importDocmap(url: string): Promise<ImportDocmapOutput[]> {
       };
     }),
   );
+
+  return {
+    results,
+  };
 }


### PR DESCRIPTION
Currently, the `importDocmaps` workflow will wait until all child `importDocmap` workflows resolve, then sync the statefile. 

This means we can't run overlapping `importDocmaps` workflows because later runs don't have an up to date state file.

This change async starts the child workflows, syncs the statefile, then awaits the children - allowing us to run multiple overlapping `importDocmaps` workflows as long as the state is sync'd (longer for a first run than subsequent runs).

Also tidied up the return types a little while there.