### PR TITLE
feat: upgrade @elifesciences/docmap-ts to v0.0.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.374.0",
     "@aws-sdk/credential-providers": "^3.374.0",
-    "@elifesciences/docmap-ts": "https://github.com/elifesciences/docmap-ts#v0.0.34",
+    "@elifesciences/docmap-ts": "https://github.com/elifesciences/docmap-ts#v0.0.35",
     "@stencila/encoda": "1.0.1",
     "@stencila/schema": "^1.18.0",
     "@temporalio/activity": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,14 +1655,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@elifesciences/docmap-ts@https://github.com/elifesciences/docmap-ts#v0.0.34":
-  version: 0.0.34
-  resolution: "@elifesciences/docmap-ts@https://github.com/elifesciences/docmap-ts.git#commit=ee882838f2fbb22564346ddb6bd24e33fdf2b041"
+"@elifesciences/docmap-ts@https://github.com/elifesciences/docmap-ts#v0.0.35":
+  version: 0.0.35
+  resolution: "@elifesciences/docmap-ts@https://github.com/elifesciences/docmap-ts.git#commit=e2ef29b2057286a3632e6c10794ed095021591d9"
   dependencies:
     "@tsconfig/node18": ^1.0.1
     ts-node: ^10.9.1
     typescript: ^4.9.3
-  checksum: 2233a8a3c498e8014557a04c5f26b8cedfdfbf7b1a90601b0398d34c37be5109bb994e691a176e0fac331c5f55b05141d7135135561c0f7567f8abfe59fd2aef
+  checksum: 786cfa07780f57c9f8f28e9fac25a929cef72c8701a4deb33470684754f2e41df1db08b9866d27843aee7da48057898d848031e30f3a145abb6f828dc89f067b
   languageName: node
   linkType: hard
 
@@ -7581,7 +7581,7 @@ __metadata:
     "@aws-sdk/client-s3": ^3.374.0
     "@aws-sdk/credential-providers": ^3.374.0
     "@aws-sdk/util-stream-node": ^3.374.0
-    "@elifesciences/docmap-ts": "https://github.com/elifesciences/docmap-ts#v0.0.34"
+    "@elifesciences/docmap-ts": "https://github.com/elifesciences/docmap-ts#v0.0.35"
     "@stencila/encoda": 1.0.1
     "@stencila/schema": ^1.18.0
     "@temporalio/activity": ^1.7.4


### PR DESCRIPTION
The @elifesciences/docmap-ts package has been updated from v0.0.34 to v0.0.35. The changes have been reflected in package.json and yarn.lock files.