### PR TITLE
Improvements to DocMap hashing:

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.2.2",
     "decompress": "^4.2.1",
     "fast-xml-parser": "^4.0.11",
+    "object-hash": "^3.0.0",
     "ts-node": "10.9.2",
     "typescript": "5.3.3"
   },
@@ -31,6 +32,7 @@
     "@types/eslint": "8.56.0",
     "@types/jest": "^29.2.5",
     "@types/node": "^16.18.68",
+    "@types/object-hash": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "6.1.0",
     "@typescript-eslint/parser": "^6.0.0",
     "aws-sdk-client-mock": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "axios": "^1.2.2",
     "decompress": "^4.2.1",
     "fast-xml-parser": "^4.0.11",
-    "object-hash": "^3.0.0",
     "ts-node": "10.9.2",
     "typescript": "5.3.3"
   },
@@ -32,7 +31,6 @@
     "@types/eslint": "8.56.0",
     "@types/jest": "^29.2.5",
     "@types/node": "^16.18.68",
-    "@types/object-hash": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "6.1.0",
     "@typescript-eslint/parser": "^6.0.0",
     "aws-sdk-client-mock": "^3.0.0",

--- a/src/activities/find-all-docmaps.test.ts
+++ b/src/activities/find-all-docmaps.test.ts
@@ -7,9 +7,7 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import { filterDocmapIndex, mergeDocmapState } from './find-all-docmaps';
-import { createHash } from 'crypto';
 import { createDocMapHash } from '../utils/create-docmap-hash';
-import { DocMap } from '@elifesciences/docmap-ts';
 
 jest.mock('axios');
 const mockS3Client = mockClient(S3Client);

--- a/src/activities/find-all-docmaps.test.ts
+++ b/src/activities/find-all-docmaps.test.ts
@@ -7,7 +7,9 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import { filterDocmapIndex, mergeDocmapState } from './find-all-docmaps';
+import { createHash } from 'crypto';
 import { createDocMapHash } from '../utils/create-docmap-hash';
+import { DocMap } from '@elifesciences/docmap-ts';
 
 jest.mock('axios');
 const mockS3Client = mockClient(S3Client);
@@ -20,7 +22,9 @@ jest.mock('../config', () => ({
 }));
 
 describe('docmap-filter', () => {
-  const mockHashes = createDocMapHash({ id: 'fake-docmap'});
+  const mockId = 'fake-docmap';
+  const mockedHash = 'fce9d372cab6bb01073a1868b3a2749d';
+  const mockedIdHash = '4e9eeaf1649334fa428ea6c4f4343849';
 
   beforeEach(() => {
     mockS3Client.reset();
@@ -59,8 +63,8 @@ describe('docmap-filter', () => {
       expect(result?.length).toStrictEqual(1);
       expect(result?.[0].docMapId).toStrictEqual('fake-docmap');
       expect(result?.length).toStrictEqual(1);
-      expect(result?.[0].docMapHash).toStrictEqual(mockHashes.docMapHash);
-      expect(result?.[0].docMapIdHash).toStrictEqual(mockHashes.docMapIdHash);
+      expect(result?.[0].docMapHash).toStrictEqual(mockedHash);
+      expect(result?.[0].docMapIdHash).toStrictEqual(mockedIdHash);
     });
 
     it('returns new docmaps (that are not hashed in the state file)', async () => {
@@ -68,7 +72,7 @@ describe('docmap-filter', () => {
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
-        data: { docmaps: [{ id: mockHashes.docMapId }] },
+        data: { docmaps: [{ id: mockId }] },
         status: 200,
       }));
       mockS3Client.on(GetObjectCommand).rejects(new NoSuchKey({
@@ -81,9 +85,9 @@ describe('docmap-filter', () => {
 
       // Assert
       expect(result).toStrictEqual([{
-        docMapId: mockHashes.docMapId,
-        docMapHash: mockHashes.docMapHash,
-        docMapIdHash: mockHashes.docMapIdHash,
+        docMapId: mockId,
+        docMapHash: mockedHash,
+        docMapIdHash: mockedIdHash,
       }]);
     });
 
@@ -92,7 +96,7 @@ describe('docmap-filter', () => {
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
-        data: { docmaps: [{ id: mockHashes.docMapId }] },
+        data: { docmaps: [{ id: mockId }] },
         status: 200,
       }));
       mockS3Client.on(GetObjectCommand).rejects(new NoSuchKey({
@@ -105,9 +109,9 @@ describe('docmap-filter', () => {
 
       // Assert
       expect(result).toStrictEqual([{
-        docMapId: mockHashes.docMapId,
-        docMapHash: mockHashes.docMapHash,
-        docMapIdHash: mockHashes.docMapIdHash,
+        docMapId: mockId,
+        docMapHash: mockedHash,
+        docMapIdHash: mockedIdHash,
       }]);
     });
 
@@ -116,16 +120,16 @@ describe('docmap-filter', () => {
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
-        data: { docmaps: [{ id: mockHashes.docMapId }] },
+        data: { docmaps: [{ id: mockId }] },
         status: 200,
       }));
 
       const stream = new Readable();
       stream.push(JSON.stringify([
         {
-          docMapId: mockHashes.docMapId,
-          docMapHash: mockHashes.docMapHash,
-          docMapIdHash: mockHashes.docMapIdHash,
+          docMapId: mockId,
+          docMapHash: mockedHash,
+          docMapIdHash: mockedIdHash,
         },
       ]));
       stream.push(null);
@@ -172,9 +176,9 @@ describe('docmap-filter', () => {
 
       // Act
       const result = await mergeDocmapState([{
-        docMapId: mockHashes.docMapId,
-        docMapHash: mockHashes.docMapHash,
-        docMapIdHash: mockHashes.docMapIdHash,
+        docMapId: mockId,
+        docMapHash: mockedHash,
+        docMapIdHash: mockedIdHash,
       }], 'state-file.json');
 
       // Assert
@@ -184,9 +188,9 @@ describe('docmap-filter', () => {
         Bucket: 'test-bucket',
         Key: 'automation/state/state-file.json',
         Body: JSON.stringify([{
-          docMapId: mockHashes.docMapId,
-          docMapHash: mockHashes.docMapHash,
-          docMapIdHash: mockHashes.docMapIdHash,
+          docMapId: mockId,
+          docMapHash: mockedHash,
+          docMapIdHash: mockedIdHash,
         }]),
       });
     });

--- a/src/activities/find-all-docmaps.test.ts
+++ b/src/activities/find-all-docmaps.test.ts
@@ -7,9 +7,7 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import { filterDocmapIndex, mergeDocmapState } from './find-all-docmaps';
-import { createHash } from 'crypto';
 import { createDocMapHash } from '../utils/create-docmap-hash';
-import { DocMap } from '@elifesciences/docmap-ts';
 
 jest.mock('axios');
 const mockS3Client = mockClient(S3Client);
@@ -22,9 +20,7 @@ jest.mock('../config', () => ({
 }));
 
 describe('docmap-filter', () => {
-  const mockId = 'fake-docmap';
-  const mockedHash = 'fce9d372cab6bb01073a1868b3a2749d';
-  const mockedIdHash = '4e9eeaf1649334fa428ea6c4f4343849';
+  const mockHashes = createDocMapHash({ id: 'fake-docmap'});
 
   beforeEach(() => {
     mockS3Client.reset();
@@ -63,8 +59,8 @@ describe('docmap-filter', () => {
       expect(result?.length).toStrictEqual(1);
       expect(result?.[0].docMapId).toStrictEqual('fake-docmap');
       expect(result?.length).toStrictEqual(1);
-      expect(result?.[0].docMapHash).toStrictEqual(mockedHash);
-      expect(result?.[0].docMapIdHash).toStrictEqual(mockedIdHash);
+      expect(result?.[0].docMapHash).toStrictEqual(mockHashes.docMapHash);
+      expect(result?.[0].docMapIdHash).toStrictEqual(mockHashes.docMapIdHash);
     });
 
     it('returns new docmaps (that are not hashed in the state file)', async () => {
@@ -72,7 +68,7 @@ describe('docmap-filter', () => {
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
-        data: { docmaps: [{ id: mockId }] },
+        data: { docmaps: [{ id: mockHashes.docMapId }] },
         status: 200,
       }));
       mockS3Client.on(GetObjectCommand).rejects(new NoSuchKey({
@@ -85,9 +81,9 @@ describe('docmap-filter', () => {
 
       // Assert
       expect(result).toStrictEqual([{
-        docMapId: mockId,
-        docMapHash: mockedHash,
-        docMapIdHash: mockedIdHash,
+        docMapId: mockHashes.docMapId,
+        docMapHash: mockHashes.docMapHash,
+        docMapIdHash: mockHashes.docMapIdHash,
       }]);
     });
 
@@ -96,7 +92,7 @@ describe('docmap-filter', () => {
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
-        data: { docmaps: [{ id: mockId }] },
+        data: { docmaps: [{ id: mockHashes.docMapId }] },
         status: 200,
       }));
       mockS3Client.on(GetObjectCommand).rejects(new NoSuchKey({
@@ -109,9 +105,9 @@ describe('docmap-filter', () => {
 
       // Assert
       expect(result).toStrictEqual([{
-        docMapId: mockId,
-        docMapHash: mockedHash,
-        docMapIdHash: mockedIdHash,
+        docMapId: mockHashes.docMapId,
+        docMapHash: mockHashes.docMapHash,
+        docMapIdHash: mockHashes.docMapIdHash,
       }]);
     });
 
@@ -120,16 +116,16 @@ describe('docmap-filter', () => {
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
-        data: { docmaps: [{ id: mockId }] },
+        data: { docmaps: [{ id: mockHashes.docMapId }] },
         status: 200,
       }));
 
       const stream = new Readable();
       stream.push(JSON.stringify([
         {
-          docMapId: mockId,
-          docMapHash: mockedHash,
-          docMapIdHash: mockedIdHash,
+          docMapId: mockHashes.docMapId,
+          docMapHash: mockHashes.docMapHash,
+          docMapIdHash: mockHashes.docMapIdHash,
         },
       ]));
       stream.push(null);
@@ -176,9 +172,9 @@ describe('docmap-filter', () => {
 
       // Act
       const result = await mergeDocmapState([{
-        docMapId: mockId,
-        docMapHash: mockedHash,
-        docMapIdHash: mockedIdHash,
+        docMapId: mockHashes.docMapId,
+        docMapHash: mockHashes.docMapHash,
+        docMapIdHash: mockHashes.docMapIdHash,
       }], 'state-file.json');
 
       // Assert
@@ -188,9 +184,9 @@ describe('docmap-filter', () => {
         Bucket: 'test-bucket',
         Key: 'automation/state/state-file.json',
         Body: JSON.stringify([{
-          docMapId: mockId,
-          docMapHash: mockedHash,
-          docMapIdHash: mockedIdHash,
+          docMapId: mockHashes.docMapId,
+          docMapHash: mockHashes.docMapHash,
+          docMapIdHash: mockHashes.docMapIdHash,
         }]),
       });
     });

--- a/src/activities/find-all-docmaps.test.ts
+++ b/src/activities/find-all-docmaps.test.ts
@@ -1,13 +1,15 @@
 import { Readable } from 'stream';
 import axios from 'axios';
 import { mocked } from 'jest-mock';
-import { MD5 } from 'object-hash';
 import {
   GetObjectCommand, NoSuchKey, PutObjectCommand, S3Client,
 } from '@aws-sdk/client-s3';
 import { mockClient } from 'aws-sdk-client-mock';
 import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import { filterDocmapIndex, mergeDocmapState } from './find-all-docmaps';
+import { createHash } from 'crypto';
+import { createDocMapHash } from '../utils/create-docmap-hash';
+import { DocMap } from '@elifesciences/docmap-ts';
 
 jest.mock('axios');
 const mockS3Client = mockClient(S3Client);
@@ -20,6 +22,10 @@ jest.mock('../config', () => ({
 }));
 
 describe('docmap-filter', () => {
+  const mockId = 'fake-docmap';
+  const mockedHash = 'fce9d372cab6bb01073a1868b3a2749d';
+  const mockedIdHash = '4e9eeaf1649334fa428ea6c4f4343849';
+
   beforeEach(() => {
     mockS3Client.reset();
   });
@@ -42,8 +48,6 @@ describe('docmap-filter', () => {
     it('returns docmaps found in index', async () => {
       // Arrange
       const mockedGet = mocked(axios.get);
-      const mockedHash = MD5({ id: 'fake-docmap' });
-      const mockedIdHash = MD5('fake-docmap');
 
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
@@ -65,9 +69,6 @@ describe('docmap-filter', () => {
 
     it('returns new docmaps (that are not hashed in the state file)', async () => {
       // Arrange
-      const mockId = 'fake-docmap';
-      const mockedHash = MD5({ id: mockId });
-      const mockedIdHash = MD5(mockId);
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
@@ -92,9 +93,6 @@ describe('docmap-filter', () => {
 
     it('returns new docmaps (that are not hashed in the state file)', async () => {
       // Arrange
-      const mockId = 'fake-docmap';
-      const mockedHash = MD5({ id: mockId });
-      const mockedIdHash = MD5(mockId);
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
@@ -119,8 +117,6 @@ describe('docmap-filter', () => {
 
     it('skips existing docmaps (that are hashed in the state file)', async () => {
       // Arrange
-      const mockId = 'fake-docmap';
-
       const mockedGet = mocked(axios.get);
       // @ts-ignore
       mockedGet.mockImplementation(() => Promise.resolve({
@@ -128,8 +124,6 @@ describe('docmap-filter', () => {
         status: 200,
       }));
 
-      const mockedHash = MD5({ id: mockId });
-      const mockedIdHash = MD5(mockId);
       const stream = new Readable();
       stream.push(JSON.stringify([
         {
@@ -175,9 +169,6 @@ describe('docmap-filter', () => {
     });
 
     it('creates a new state file with a docmap hash', async () => {
-      const mockId = 'fake-docmap';
-      const mockedHash = MD5({ id: mockId });
-      const mockedIdHash = MD5(mockId);
       mockS3Client.on(GetObjectCommand).rejects(new NoSuchKey({
         $metadata: {},
         message: 'No Such Key',
@@ -206,15 +197,9 @@ describe('docmap-filter', () => {
 
     it('merges docmaps into exsiting state file', async () => {
       // Arrange
-      const mockDocmap1Id = 'fake-docmap1';
-      const mockDocmap1Hash = MD5({ id: mockDocmap1Id });
-      const mockDocmap1IdHash = MD5(mockDocmap1Id);
+      const mockDocmap1Hashes = createDocMapHash({ id: 'fake-docmap1' });
       const stream = new Readable();
-      stream.push(JSON.stringify([{
-        docMapId: mockDocmap1Id,
-        docMapHash: mockDocmap1Hash,
-        docMapIdHash: mockDocmap1IdHash,
-      }]));
+      stream.push(JSON.stringify([mockDocmap1Hashes]));
       stream.push(null);
       const sdkStream = sdkStreamMixin(stream);
       mockS3Client.on(GetObjectCommand).resolves({
@@ -222,14 +207,8 @@ describe('docmap-filter', () => {
       });
 
       // Act
-      const mockDocmap2Id = 'fake-docmap2';
-      const mockDocmap2Hash = MD5({ id: mockDocmap2Id });
-      const mockDocmap2IdHash = MD5(mockDocmap2Id);
-      const result = await mergeDocmapState([{
-        docMapId: mockDocmap2Id,
-        docMapHash: mockDocmap2Hash,
-        docMapIdHash: mockDocmap2IdHash,
-      }], 'state-file.json');
+      const mockDocmap2Hashes = createDocMapHash({ id: 'fake-docmap1' });
+      const result = await mergeDocmapState([mockDocmap2Hashes], 'state-file.json');
 
       // Assert
       expect(result).toStrictEqual(true);
@@ -237,18 +216,7 @@ describe('docmap-filter', () => {
       expect(mockS3Client.commandCalls(PutObjectCommand)[0].args[0].input).toStrictEqual({
         Bucket: 'test-bucket',
         Key: 'automation/state/state-file.json',
-        Body: JSON.stringify([
-          {
-            docMapId: mockDocmap1Id,
-            docMapHash: mockDocmap1Hash,
-            docMapIdHash: mockDocmap1IdHash,
-          },
-          {
-            docMapId: mockDocmap2Id,
-            docMapHash: mockDocmap2Hash,
-            docMapIdHash: mockDocmap2IdHash,
-          },
-        ]),
+        Body: JSON.stringify([mockDocmap1Hashes, mockDocmap2Hashes]),
       });
     });
   });

--- a/src/activities/find-all-docmaps.ts
+++ b/src/activities/find-all-docmaps.ts
@@ -1,23 +1,8 @@
 import axios from 'axios';
-import { DocMap } from '@elifesciences/docmap-ts';
-import { MD5 } from 'object-hash';
 import { GetObjectCommand, NoSuchKey, PutObjectCommand } from '@aws-sdk/client-s3';
 import { constructEPPStateS3FilePath, getEPPS3Client } from '../S3Bucket';
-
-type DocMapIndex = {
-  docmaps: DocMap[],
-};
-
-type DocMapHashes = {
-  docMapId: string,
-  docMapHash: string,
-  docMapIdHash: string,
-};
-
-type DocMapWithHashes = {
-  docMap: DocMap,
-  docMapHashes: DocMapHashes,
-};
+import { DocMapHashes, DocMapIndex, DocMapWithHashes } from '../types';
+import { createDocMapHash } from '../utils/create-docmap-hash';
 
 export const filterDocmapIndex = async (docMapIndex: string, s3StateFile?: string, start?: number, end?: number): Promise<DocMapHashes[]> => {
   const docmapHashes: DocMapHashes[] = [];
@@ -44,11 +29,7 @@ export const filterDocmapIndex = async (docMapIndex: string, s3StateFile?: strin
 
   const importableDocmapsWithHashes = result.docmaps.map<DocMapWithHashes>((docMap) => ({
     docMap,
-    docMapHashes: {
-      docMapId: docMap.id,
-      docMapHash: MD5(docMap),
-      docMapIdHash: MD5(docMap.id),
-    },
+    docMapHashes: createDocMapHash(docMap),
   }))
     .filter((docMapWithHashes) => !docmapHashes.some((hash) => hash.docMapHash === docMapWithHashes.docMapHashes.docMapHash))
     .slice(start, end);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { DocMap } from '@elifesciences/docmap-ts';
+
 export type ImportDocmapsMessage = {
   status: 'SUCCESS' | 'SKIPPED'
   message: string;
@@ -10,4 +12,20 @@ export type ImportDocmapMessage = {
     versionIdentifier: string,
     result: string,
   }[]
+  hashes: DocMapHashes,
+};
+
+export type DocMapIndex = {
+  docmaps: DocMap[],
+};
+
+export type DocMapHashes = {
+  docMapId: string,
+  docMapHash: string,
+  docMapIdHash: string,
+};
+
+export type DocMapWithHashes = {
+  docMap: DocMap,
+  docMapHashes: DocMapHashes,
 };

--- a/src/utils/create-docmap-hash.ts
+++ b/src/utils/create-docmap-hash.ts
@@ -1,16 +1,12 @@
-import { createHash } from 'crypto';
+import { MD5 } from 'object-hash';
 import { DocMapHashes } from '../types';
 
 type DocMapLikeWithId = {
   id: string,
 };
 
-export const createDocMapHash = (docMap: DocMapLikeWithId): DocMapHashes => {
-  const docMapHash = createHash('md5').update(JSON.stringify(docMap)).digest('hex');
-  const docMapIdHash = createHash('md5').update(docMap.id).digest('hex');
-  return {
-    docMapId: docMap.id,
-    docMapHash,
-    docMapIdHash,
-  };
-};
+export const createDocMapHash = (docMap: DocMapLikeWithId): DocMapHashes => ({
+  docMapId: docMap.id,
+  docMapHash: MD5(docMap),
+  docMapIdHash: MD5(docMap.id),
+});

--- a/src/utils/create-docmap-hash.ts
+++ b/src/utils/create-docmap-hash.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'crypto';
+import { DocMapHashes } from '../types';
+
+type DocMapLikeWithId = {
+  id: string,
+};
+
+export const createDocMapHash = (docMap: DocMapLikeWithId): DocMapHashes => {
+  const docMapHash = createHash('md5').update(JSON.stringify(docMap)).digest('hex');
+  const docMapIdHash = createHash('md5').update(docMap.id).digest('hex');
+  return {
+    docMapId: docMap.id,
+    docMapHash,
+    docMapIdHash,
+  };
+};

--- a/src/utils/create-docmap-hash.ts
+++ b/src/utils/create-docmap-hash.ts
@@ -1,12 +1,16 @@
-import { MD5 } from 'object-hash';
+import { createHash } from 'crypto';
 import { DocMapHashes } from '../types';
 
 type DocMapLikeWithId = {
   id: string,
 };
 
-export const createDocMapHash = (docMap: DocMapLikeWithId): DocMapHashes => ({
-  docMapId: docMap.id,
-  docMapHash: MD5(docMap),
-  docMapIdHash: MD5(docMap.id),
-});
+export const createDocMapHash = (docMap: DocMapLikeWithId): DocMapHashes => {
+  const docMapHash = createHash('md5').update(JSON.stringify(docMap)).digest('hex');
+  const docMapIdHash = createHash('md5').update(docMap.id).digest('hex');
+  return {
+    docMapId: docMap.id,
+    docMapHash,
+    docMapIdHash,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,6 +4416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/object-hash@npm:^3.0.2":
+  version: 3.0.6
+  resolution: "@types/object-hash@npm:3.0.6"
+  checksum: 2c7979d4e540af817b99c09fb4c2fed1c0b0e14342df474d8dcde4165a82c440b038341fd66fe998d9f86acdd5cccc65ba8092315e39e7c2114f945fa70aaa56
+  languageName: node
+  linkType: hard
+
 "@types/responselike@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/responselike@npm:1.0.0"
@@ -7595,6 +7602,7 @@ __metadata:
     "@types/eslint": 8.56.0
     "@types/jest": ^29.2.5
     "@types/node": ^16.18.68
+    "@types/object-hash": ^3.0.2
     "@typescript-eslint/eslint-plugin": 6.1.0
     "@typescript-eslint/parser": ^6.0.0
     aws-sdk-client-mock: ^3.0.0
@@ -7612,6 +7620,7 @@ __metadata:
     jest: 29.7.0
     jest-mock: ^29.3.1
     nodemon: ^3.0.0
+    object-hash: ^3.0.0
     ts-jest: 29.1.1
     ts-node: 10.9.2
     typescript: 5.3.3
@@ -12587,6 +12596,13 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
+  languageName: node
+  linkType: hard
+
+"object-hash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "object-hash@npm:3.0.0"
+  checksum: 80b4904bb3857c52cc1bfd0b52c0352532ca12ed3b8a6ff06a90cd209dfda1b95cee059a7625eb9da29537027f68ac4619363491eedb2f5d3dddbba97494fd6c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,13 +4416,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/object-hash@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "@types/object-hash@npm:3.0.2"
-  checksum: 0332e59074e7df2e74c093a7419c05c1e1c5ae1e12d3779f3240b3031835ff045b4ac591362be0b411ace24d3b5e760386b434761c33af25904f7a3645cb3785
-  languageName: node
-  linkType: hard
-
 "@types/responselike@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/responselike@npm:1.0.0"
@@ -7602,7 +7595,6 @@ __metadata:
     "@types/eslint": 8.56.0
     "@types/jest": ^29.2.5
     "@types/node": ^16.18.68
-    "@types/object-hash": ^3.0.2
     "@typescript-eslint/eslint-plugin": 6.1.0
     "@typescript-eslint/parser": ^6.0.0
     aws-sdk-client-mock: ^3.0.0
@@ -7620,7 +7612,6 @@ __metadata:
     jest: 29.7.0
     jest-mock: ^29.3.1
     nodemon: ^3.0.0
-    object-hash: ^3.0.0
     ts-jest: 29.1.1
     ts-node: 10.9.2
     typescript: 5.3.3
@@ -12596,13 +12587,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-hash@npm:3.0.0"
-  checksum: 80b4904bb3857c52cc1bfd0b52c0352532ca12ed3b8a6ff06a90cd209dfda1b95cee059a7625eb9da29537027f68ac4619363491eedb2f5d3dddbba97494fd6c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,13 +4416,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/object-hash@npm:^3.0.2":
-  version: 3.0.6
-  resolution: "@types/object-hash@npm:3.0.6"
-  checksum: 2c7979d4e540af817b99c09fb4c2fed1c0b0e14342df474d8dcde4165a82c440b038341fd66fe998d9f86acdd5cccc65ba8092315e39e7c2114f945fa70aaa56
-  languageName: node
-  linkType: hard
-
 "@types/responselike@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/responselike@npm:1.0.0"
@@ -7602,7 +7595,6 @@ __metadata:
     "@types/eslint": 8.56.0
     "@types/jest": ^29.2.5
     "@types/node": ^16.18.68
-    "@types/object-hash": ^3.0.2
     "@typescript-eslint/eslint-plugin": 6.1.0
     "@typescript-eslint/parser": ^6.0.0
     aws-sdk-client-mock: ^3.0.0
@@ -7620,7 +7612,6 @@ __metadata:
     jest: 29.7.0
     jest-mock: ^29.3.1
     nodemon: ^3.0.0
-    object-hash: ^3.0.0
     ts-jest: 29.1.1
     ts-node: 10.9.2
     typescript: 5.3.3
@@ -12596,13 +12587,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-hash@npm:3.0.0"
-  checksum: 80b4904bb3857c52cc1bfd0b52c0352532ca12ed3b8a6ff06a90cd209dfda1b95cee059a7625eb9da29537027f68ac4619363491eedb2f5d3dddbba97494fd6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- move docmap hash creation to a util
- generate during `docmapImport` and store in result
- move from object-hash to MD5 of JSON string