### PR TITLE
feat: add approval query to importDocmaps workflow

### DIFF
--- a/src/workflows/import-docmaps.ts
+++ b/src/workflows/import-docmaps.ts
@@ -9,7 +9,7 @@ import {
   startChild,
 } from '@temporalio/workflow';
 import type * as activities from '../activities/index';
-import {DocMapHashes, ImportDocmapsMessage} from '../types';
+import { DocMapHashes, ImportDocmapsMessage } from '../types';
 import { importDocmap } from './import-docmap';
 
 const {

--- a/src/workflows/import-docmaps.ts
+++ b/src/workflows/import-docmaps.ts
@@ -32,10 +32,15 @@ type ImportArgs = {
   end?: number,
 };
 
+type ThresholdQueryResponse = {
+  awaitingApproval: number,
+  docMapUrls: string[],
+};
+
 export type Hash = { hash: string, idHash: string };
 
 const approvalSignal = defineSignal<[boolean]>('approval');
-const thresholdQuery = defineQuery<null | string>('awaitingApproval');
+const thresholdQuery = defineQuery<null | ThresholdQueryResponse>('awaitingApproval');
 
 export async function importDocmaps({
   docMapIndexUrl, s3StateFileUrl, docMapThreshold, start, end,
@@ -52,7 +57,13 @@ export async function importDocmaps({
     };
   }
 
-  setHandler(thresholdQuery, () => (docMapThreshold && approval !== undefined && approval === null ? `awaiting approval ${docMapIdHashes.length}` : null));
+  setHandler(thresholdQuery, () => (docMapThreshold && approval !== undefined && approval === null
+    ? {
+      awaitingApproval: docMapIdHashes.length,
+      docMapUrls: docMapIdHashes.map(({ docMapId }) => docMapId),
+    }
+    : null
+  ));
 
   if (docMapThreshold && docMapIdHashes.length > docMapThreshold) {
     approval = null;


### PR DESCRIPTION
This commit introduces a new query 'awaitingApproval' to the importDocmaps workflow. The approval state is now initially undefined and will be set to null when the docMapThreshold is exceeded. The query handler is set to return true when the approval state is null, indicating that approval is being awaited.