### PR TITLE
feat: ensure there is only one entry in state file for a docMapId

### DIFF
--- a/src/activities/create-docmap-hash.ts
+++ b/src/activities/create-docmap-hash.ts
@@ -3,6 +3,7 @@ import { DocMapHashes } from '../types';
 
 type DocMapLikeWithId = {
   id: string,
+  [key: string]: any,
 };
 
 export const createDocMapHash = async (docMap: DocMapLikeWithId): Promise<DocMapHashes> => {

--- a/src/activities/find-all-docmaps.test.ts
+++ b/src/activities/find-all-docmaps.test.ts
@@ -205,7 +205,7 @@ describe('docmap-filter', () => {
       });
 
       // Act
-      const mockDocmap2Hashes = await createDocMapHash({ id: 'fake-docmap1' });
+      const mockDocmap2Hashes = await createDocMapHash({ id: 'fake-docmap2' });
       const result = await mergeDocmapState([mockDocmap2Hashes], 'state-file.json');
 
       // Assert
@@ -215,6 +215,32 @@ describe('docmap-filter', () => {
         Bucket: 'test-bucket',
         Key: 'automation/state/state-file.json',
         Body: JSON.stringify([mockDocmap1Hashes, mockDocmap2Hashes]),
+      });
+    });
+
+    it('merges docmaps ensuring one entry for docMapId', async () => {
+      // Arrange
+      const mockDocmap1Hashes = await createDocMapHash({ id: 'fake-docmap1' });
+      const stream = new Readable();
+      stream.push(JSON.stringify([mockDocmap1Hashes]));
+      stream.push(null);
+      const sdkStream = sdkStreamMixin(stream);
+      mockS3Client.on(GetObjectCommand).resolves({
+        Body: sdkStream,
+      });
+
+      // Act
+      const mockDocmap2Hashes = await createDocMapHash({ id: 'fake-docmap2' });
+      const mockDocmap3Hashes = await createDocMapHash({ id: 'fake-docmap1', created: '2022-11-11T05:02:51+00:00' });
+      const result = await mergeDocmapState([mockDocmap2Hashes, mockDocmap3Hashes], 'state-file.json');
+
+      // Assert
+      expect(result).toStrictEqual(true);
+
+      expect(mockS3Client.commandCalls(PutObjectCommand)[0].args[0].input).toStrictEqual({
+        Bucket: 'test-bucket',
+        Key: 'automation/state/state-file.json',
+        Body: JSON.stringify([mockDocmap3Hashes, mockDocmap2Hashes]),
       });
     });
   });

--- a/src/activities/find-all-docmaps.test.ts
+++ b/src/activities/find-all-docmaps.test.ts
@@ -243,5 +243,11 @@ describe('docmap-filter', () => {
         Body: JSON.stringify([mockDocmap3Hashes, mockDocmap2Hashes]),
       });
     });
+
+    it('returns false if s3 state file is not defined', async () => {
+      const mockDocmap1Hashes = await createDocMapHash({ id: 'fake-docmap1' });
+      const result = await mergeDocmapState([mockDocmap1Hashes]);
+      expect(result).toStrictEqual(false);
+    });
   });
 });


### PR DESCRIPTION
Enhance the `createDocMapHash` function to allow any key-value pairs in the `DocMapLikeWithId` type. Refactor the `mergeDocmapState` function to use a Map for merging docmap hashes, ensuring a single entry for each `docMapId`. Update the test cases to cover the new logic in the `mergeDocmapState` function.