### PR TITLE
Revert "[#1073]: fix stuck workflows when a preprint with content block without an S3 source. "

### DIFF
--- a/src/activities/copy-source-meca.ts
+++ b/src/activities/copy-source-meca.ts
@@ -14,7 +14,6 @@ import {
   getEPPS3Client,
   getMecaS3Client, parseS3Path, sharedS3,
 } from '../S3Bucket';
-import { NonRetryableError } from '../errors';
 
 type CopySourcePreprintToEPPOutput = {
   path: S3File,
@@ -136,7 +135,7 @@ export const s3GetSourceAndPutDestination = async (source: S3File, destination: 
 export const copySourcePreprintToEPP = async (version: VersionedReviewedPreprint): Promise<CopySourcePreprintToEPPOutput> => {
   const sourceS3Url = version.preprint.content?.find((url) => url.startsWith('s3://'));
   if (sourceS3Url === undefined) {
-    throw new NonRetryableError(`Cannot import content - no s3 URL found in content strings [${version.preprint.content?.join(',')}]`);
+    throw Error(`Cannot import content - no s3 URL found in content strings [${version.preprint.content?.join(',')}]`);
   }
 
   // Create source.txt in S3 with s3Filename as its content


### PR DESCRIPTION
Reverts elifesciences/enhanced-preprints-import#3913