### PR TITLE
Change API healthcheck URL in docker-compose.yaml [elifesciences/enhanced-preprints-issues#1103]

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -271,7 +271,7 @@ services:
   api:
     image: ghcr.io/elifesciences/enhanced-preprints-server:master-30e69b72-20240613.0005
     healthcheck:
-      test: sh -c 'apk add curl; curl http://api:3000/'
+      test: sh -c 'apk add curl; curl http://localhost:3000/'
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
Updated the test URL used for the API healthcheck in the docker-compose file. It now uses "localhost" instead of "api".